### PR TITLE
libs/platform/windows: implemented abspath and unlink

### DIFF
--- a/libs/platform/osutils/windows/CMakeLists.txt
+++ b/libs/platform/osutils/windows/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_library(platform-osutils STATIC
+    abspath.c
     chsize.c    
     exec.c  
-    sleep.c    
+    sleep.c   
+    unlink.c 
 )
 target_include_directories(platform-osutils PRIVATE ../../include)

--- a/libs/platform/osutils/windows/abspath.c
+++ b/libs/platform/osutils/windows/abspath.c
@@ -22,13 +22,11 @@
 char* platform_abspath(const char* path)
 {
     char *fullPath = calloc(1, MAX_PATH);
-    if (fullPath == NULL)
-    {
+    if (fullPath == NULL) {
         return NULL;
     }
 
-    if (GetFullPathName(path, MAX_PATH, fullPath, NULL) == 0)
-    {
+    if (GetFullPathName(path, MAX_PATH, fullPath, NULL) == 0) {
         free(fullPath);
         return NULL;
     }

--- a/libs/platform/osutils/windows/abspath.c
+++ b/libs/platform/osutils/windows/abspath.c
@@ -21,7 +21,17 @@
 
 char* platform_abspath(const char* path)
 {
-    char abs_path[MAX_PATH];
+    char *fullPath = calloc(1, MAX_PATH);
+    if (fullPath == NULL)
+    {
+        return NULL;
+    }
 
-    return GetFullPathName(path, MAX_PATH, abs_path, NULL);
+    if (GetFullPathName(path, MAX_PATH, fullPath, NULL) == 0)
+    {
+        free(fullPath);
+        return NULL;
+    }
+    
+    return fullPath;
 }

--- a/libs/platform/osutils/windows/abspath.c
+++ b/libs/platform/osutils/windows/abspath.c
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2024, Philip Meulengracht
+ *
+ * This program is free software : you can redistribute it and / or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation ? , either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ */
+
+#include <chef/platform.h>
+#include <stdlib.h>
+
+char* platform_abspath(const char* path)
+{
+    char abs_path[MAX_PATH];
+
+    return GetFullPathName(path, MAX_PATH, abs_path, NULL);
+}

--- a/libs/platform/osutils/windows/unlink.c
+++ b/libs/platform/osutils/windows/unlink.c
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2024, Philip Meulengracht
+ *
+ * This program is free software : you can redistribute it and / or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation ? , either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <chef/platform.h>
+#include <stdio.h>
+
+int platform_unlink(const char* path)
+{
+    return remove(path);
+}


### PR DESCRIPTION
Istedet for realpath på linux kan vi bruge GetFullPath på windows. Istedet for unlink på linux kan vi bruge remove på windows.