### PR TITLE
many: chef 1.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,7 @@
 
 # Projects
 build/
-.fridge
-.oven
 .kitchen
+.vchcache
 *.pack
 .vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/chef-config.h.in"
                @ONLY
 )
 
+if(MSVC)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+endif()
+
 add_subdirectory(protocols)
 add_subdirectory(libs)
 add_subdirectory(tools)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14.3)
-project(chef VERSION "1.2.0")
+project(chef VERSION "1.2.1")
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 

--- a/examples/hello.yaml
+++ b/examples/hello.yaml
@@ -8,6 +8,13 @@ project:
   version: 1.0.0
   license: MIT
 
+environment:
+  host:
+    packages:
+      - cmake
+      - make
+      - gcc
+
 recipes:
   - name: hello
     path: hello-world

--- a/examples/hello.yaml
+++ b/examples/hello.yaml
@@ -11,9 +11,8 @@ project:
 environment:
   host:
     packages:
+      - build-essential
       - cmake
-      - make
-      - gcc
 
 recipes:
   - name: hello
@@ -35,5 +34,5 @@ packs:
   type: application
   commands:
   - name: hello
-    path: /usr/local/bin/hello-world
+    path: /usr/bin/hello-world
     type: executable

--- a/libs/chefclient/account.c
+++ b/libs/chefclient/account.c
@@ -17,6 +17,7 @@
  */
 
 #include <chef/client.h>
+#include <chef/platform.h>
 #include <chef/api/account.h>
 #include <curl/curl.h>
 #include <errno.h>

--- a/libs/chefclient/account.c
+++ b/libs/chefclient/account.c
@@ -74,12 +74,12 @@ static int __parse_account(const char* response, struct chef_account** accountOu
     // parse the account
     member = json_object_get(root, "publisher-name");
     if (member) {
-        account->publisher_name = strdup(json_string_value(member));
+        account->publisher_name = platform_strdup(json_string_value(member));
     }
 
     member = json_object_get(root, "publisher-email");
     if (member) {
-        account->publisher_email = strdup(json_string_value(member));
+        account->publisher_email = platform_strdup(json_string_value(member));
     }
 
     member = json_object_get(root, "status");
@@ -284,7 +284,7 @@ void chef_account_set_publisher_name(struct chef_account* account, const char* p
         free((void*)account->publisher_name);
     }
 
-    account->publisher_name = strdup(publisherName);
+    account->publisher_name = platform_strdup(publisherName);
 }
 
 void chef_account_set_publisher_email(struct chef_account* account, const char* publisherEmail)
@@ -298,7 +298,7 @@ void chef_account_set_publisher_email(struct chef_account* account, const char* 
         free((void*)account->publisher_email);
     }
 
-    account->publisher_email = strdup(publisherEmail);
+    account->publisher_email = platform_strdup(publisherEmail);
 }
 
 const char* chef_account_get_publisher_email(struct chef_account* account)

--- a/libs/chefclient/client.c
+++ b/libs/chefclient/client.c
@@ -95,7 +95,7 @@ static int __save_settings(void)
     }
 
     status = platform_getuserdir(path, PATH_MAX);
-    if (status != 0) {
+    if (status) {
         fprintf(stderr, "__save_settings: failed to get user directory: %s\n", strerror(errno));
         free(path);
         return -1;
@@ -104,8 +104,8 @@ static int __save_settings(void)
     // append directory, and make sure directory exists
     strcat(path, CHEF_PATH_SEPARATOR_S ".chef");
     status = platform_mkdir(path);
-    if (status != 0) {
-        fprintf(stderr, "__save_settings: failed to create directory: %s\n", strerror(errno));
+    if (status) {
+        fprintf(stderr, "__save_settings: failed to create directory %s: %s\n", path, strerror(errno));
         free(path);
         return -1;
     }

--- a/libs/chefclient/client.c
+++ b/libs/chefclient/client.c
@@ -51,7 +51,7 @@ static int __load_settings(struct chefclient* client, const char* path)
 
     snprintf(&buff[0], sizeof(buff), "%s" CHEF_PATH_SEPARATOR_S "client.json", path);;
 
-    client->settings_path = strdup(&buff[0]);
+    client->settings_path = platform_strdup(&buff[0]);
     client->settings = json_load_file(&buff[0], 0, &error);
     if (client->settings == NULL) {
         // handle if file not found

--- a/libs/chefclient/client.c
+++ b/libs/chefclient/client.c
@@ -52,14 +52,13 @@ static int __load_settings(struct chefclient* client, const char* path)
     snprintf(&buff[0], sizeof(buff), "%s" CHEF_PATH_SEPARATOR_S "client.json", path);;
 
     client->settings_path = strdup(&buff[0]);
-    client->settings = json_load_file(path, 0, &error);
+    client->settings = json_load_file(&buff[0], 0, &error);
     if (client->settings == NULL) {
         // handle if file not found
         if (json_error_code(&error) == json_error_cannot_open_file) {
             client->settings = json_object();
-        }
-        else {
-            free(path);
+        } else {
+            fprintf(stderr, "__load_settings: failed to read %s: %i\n", &buff[0], json_error_code(&error));
             return -1;
         }
     }

--- a/libs/chefclient/client.c
+++ b/libs/chefclient/client.c
@@ -47,7 +47,6 @@ static int __load_settings(struct chefclient* client, const char* path)
 {
     char         buff[PATH_MAX];
     json_error_t error;
-    int          status;
 
     snprintf(&buff[0], sizeof(buff), "%s" CHEF_PATH_SEPARATOR_S "client.json", path);;
 

--- a/libs/chefclient/download.c
+++ b/libs/chefclient/download.c
@@ -117,8 +117,8 @@ static int __parse_pack_response(const char* response, struct pack_response* pac
     }
 
     packResponse->revision = json_integer_value(json_object_get(root, "pack-revision"));
-    packResponse->token = strdup(json_string_value(json_object_get(root, "sas-token")));
-    packResponse->url = strdup(json_string_value(json_object_get(root, "blob-url")));
+    packResponse->token = platform_strdup(json_string_value(json_object_get(root, "sas-token")));
+    packResponse->url = platform_strdup(json_string_value(json_object_get(root, "blob-url")));
     json_decref(root);
 
     return 0;

--- a/libs/chefclient/download.c
+++ b/libs/chefclient/download.c
@@ -18,6 +18,7 @@
 
 #include <errno.h>
 #include <chef/client.h>
+#include <chef/platform.h>
 #include <chef/api/package.h>
 #include <curl/curl.h>
 #include <jansson.h>

--- a/libs/chefclient/find.c
+++ b/libs/chefclient/find.c
@@ -17,6 +17,7 @@
  */
 
 #include <chef/client.h>
+#include <chef/platform.h>
 #include <chef/api/package.h>
 #include <curl/curl.h>
 #include <errno.h>

--- a/libs/chefclient/find.c
+++ b/libs/chefclient/find.c
@@ -28,9 +28,9 @@ static const char* __get_json_string_safe(json_t* object, const char* key)
 {
     json_t* value = json_object_get(object, key);
     if (value != NULL && json_string_value(value) != NULL) {
-        return strdup(json_string_value(value));
+        return platform_strdup(json_string_value(value));
     }
-    return strdup("<not set>");
+    return platform_strdup("<not set>");
 }
 
 static int __get_find_url(struct chef_find_params* params, char* urlBuffer, size_t bufferSize)

--- a/libs/chefclient/info.c
+++ b/libs/chefclient/info.c
@@ -17,6 +17,7 @@
  */
 
 #include <chef/client.h>
+#include <chef/platform.h>
 #include <chef/api/package.h>
 #include <curl/curl.h>
 #include <errno.h>

--- a/libs/chefclient/info.c
+++ b/libs/chefclient/info.c
@@ -28,9 +28,9 @@ static const char* __get_json_string_safe(json_t* object, const char* key)
 {
     json_t* value = json_object_get(object, key);
     if (value != NULL && json_string_value(value) != NULL) {
-        return strdup(json_string_value(value));
+        return platform_strdup(json_string_value(value));
     }
-    return strdup("<not set>");
+    return platform_strdup("<not set>");
 }
 
 static int __get_info_url(struct chef_info_params* params, char* urlBuffer, size_t bufferSize)

--- a/libs/chefclient/oauth/devicecode.c
+++ b/libs/chefclient/oauth/devicecode.c
@@ -87,7 +87,6 @@ static int __parse_challenge_response(const char* responseBuffer, struct devicec
 {
     json_error_t error;
     json_t*      root;
-    int          status;
 
     root = json_loads(responseBuffer, 0, &error);
     if (!root) {

--- a/libs/chefclient/oauth/devicecode.c
+++ b/libs/chefclient/oauth/devicecode.c
@@ -96,9 +96,9 @@ static int __parse_challenge_response(const char* responseBuffer, struct devicec
     }
 
     // get rest of values that should be there
-    context->user_code = strdup(json_string_value(json_object_get(root, "user_code")));
-    context->device_code = strdup(json_string_value(json_object_get(root, "device_code")));
-    context->verification_uri = strdup(json_string_value(json_object_get(root, "verification_uri")));
+    context->user_code = platform_strdup(json_string_value(json_object_get(root, "user_code")));
+    context->device_code = platform_strdup(json_string_value(json_object_get(root, "device_code")));
+    context->verification_uri = platform_strdup(json_string_value(json_object_get(root, "verification_uri")));
     context->expires_in = json_integer_value(json_object_get(root, "expires_in"));
     context->interval = json_integer_value(json_object_get(root, "interval"));
 
@@ -177,13 +177,13 @@ static int __parse_token_response(const char* responseBuffer, struct token_conte
     }
 
     context->expires_in = json_integer_value(json_object_get(root, "expires_in"));
-    context->access_token = strdup(json_string_value(json_object_get(root, "access_token")));
-    context->id_token = strdup(json_string_value(json_object_get(root, "id_token")));
+    context->access_token = platform_strdup(json_string_value(json_object_get(root, "access_token")));
+    context->id_token = platform_strdup(json_string_value(json_object_get(root, "id_token")));
     
     // refresh token is optional, and we only get it for offline_access
     refreshToken = json_object_get(root, "refresh_token");
     if (refreshToken != NULL) {
-        context->refresh_token = strdup(json_string_value(refreshToken));
+        context->refresh_token = platform_strdup(json_string_value(refreshToken));
     }
 
     json_decref(root);

--- a/libs/chefclient/oauth/oauth.c
+++ b/libs/chefclient/oauth/oauth.c
@@ -26,7 +26,7 @@
 #include <string.h>
 
 extern int oauth_deviceflow_start(struct token_context* tokenContexth);
-extern json_t* g_chefSettings;
+extern json_t* chefclient_settings(void);
 
 static struct token_context g_tokenContext = { 0 };
 static char                 g_token[4096]  = { 0 };
@@ -34,8 +34,8 @@ static char                 g_token[4096]  = { 0 };
 static int __load_oauth_settings(void)
 {
     // do we have oauth settings stored?
-    if (g_chefSettings != NULL) {
-        json_t* oauth = json_object_get(g_chefSettings, "oauth");
+    if (chefclient_settings() != NULL) {
+        json_t* oauth = json_object_get(chefclient_settings(), "oauth");
         if (oauth != NULL) {
             json_t* accessToken  = json_object_get(oauth, "access-token");
             json_t* refreshToken = json_object_get(oauth, "refresh-token");
@@ -54,7 +54,7 @@ static int __load_oauth_settings(void)
 
 static void __save_oauth_settings(void)
 {
-    if (g_chefSettings != NULL) {
+    if (chefclient_settings() != NULL) {
         const char* empty = "";
         json_t*     oauth;
         json_t*     accessToken;
@@ -80,7 +80,7 @@ static void __save_oauth_settings(void)
         json_object_set_new(oauth, "refresh-token", refreshToken);
 
         // store the oauth object
-        json_object_set_new(g_chefSettings, "oauth", oauth);
+        json_object_set_new(chefclient_settings(), "oauth", oauth);
     }
 }
 

--- a/libs/chefclient/oauth/oauth.c
+++ b/libs/chefclient/oauth/oauth.c
@@ -16,6 +16,7 @@
  * 
  */
 
+#include <chef/platform.h>
 #include <curl/curl.h>
 #include <errno.h>
 #include "oauth.h"

--- a/libs/chefclient/oauth/oauth.c
+++ b/libs/chefclient/oauth/oauth.c
@@ -41,10 +41,10 @@ static int __load_oauth_settings(void)
             json_t* refreshToken = json_object_get(oauth, "refresh-token");
 
             if (json_string_value(refreshToken) != NULL && strlen(json_string_value(refreshToken)) > 0) {
-                g_tokenContext.refresh_token = strdup(json_string_value(refreshToken));
+                g_tokenContext.refresh_token = platform_strdup(json_string_value(refreshToken));
             }
             if (json_string_value(accessToken) != NULL && strlen(json_string_value(accessToken)) > 0) {
-                g_tokenContext.access_token = strdup(json_string_value(accessToken));
+                g_tokenContext.access_token = platform_strdup(json_string_value(accessToken));
             }
             return 0;
         }

--- a/libs/chefclient/publish.c
+++ b/libs/chefclient/publish.c
@@ -18,6 +18,7 @@
 
 #include <errno.h>
 #include <chef/client.h>
+#include <chef/platform.h>
 #include <chef/api/package.h>
 #include <curl/curl.h>
 #include <jansson.h>

--- a/libs/chefclient/publish.c
+++ b/libs/chefclient/publish.c
@@ -200,8 +200,8 @@ static int __parse_pack_response(const char* response, struct pack_response* pac
         return -1;
     }
 
-    packResponse->token = strdup(json_string_value(json_object_get(root, "sas-token")));
-    packResponse->url = strdup(json_string_value(json_object_get(root, "blob-url")));
+    packResponse->token = platform_strdup(json_string_value(json_object_get(root, "sas-token")));
+    packResponse->url = platform_strdup(json_string_value(json_object_get(root, "blob-url")));
     json_decref(root);
 
     return 0;

--- a/libs/chefclient/settings.c
+++ b/libs/chefclient/settings.c
@@ -86,7 +86,7 @@ static int __parse_pack_settings(const char* response, struct chef_package_setti
     // read name
     name = json_object_get(root, "name");
     if (name) {
-        settings->package = strdup(json_string_value(name));
+        settings->package = platform_strdup(json_string_value(name));
     }
 
     discoverable = json_object_get(root, "discoverable");

--- a/libs/chefclient/settings.c
+++ b/libs/chefclient/settings.c
@@ -17,6 +17,7 @@
  */
 
 #include <chef/client.h>
+#include <chef/platform.h>
 #include <chef/api/package_settings.h>
 #include <curl/curl.h>
 #include <errno.h>

--- a/libs/fridge/fridge.c
+++ b/libs/fridge/fridge.c
@@ -65,7 +65,6 @@ int fridge_initialize(const char* platform, const char* architecture)
 {
     int   status;
     char  temp[2048] = { 0 };
-    char* root;
 
     if (platform == NULL || architecture == NULL) {
         VLOG_ERROR("fridge", "fridge_initialize: platform and architecture must be specified\n");

--- a/libs/fridge/fridge.c
+++ b/libs/fridge/fridge.c
@@ -126,7 +126,7 @@ int fridge_ensure_ingredient(struct fridge_ingredient* ingredient, const char** 
         return status;
     }
     if (pathOut != NULL) {
-        *pathOut = strdup(inventory_pack_path(pack));
+        *pathOut = platform_strdup(inventory_pack_path(pack));
     }
     return fridge_store_close(g_fridge.store);
 }

--- a/libs/fridge/inventory.c
+++ b/libs/fridge/inventory.c
@@ -127,12 +127,12 @@ static int __parse_inventory(const char* json, struct fridge_inventory** invento
             json_t* version_tag = json_object_get(version, "tag");
 
             inventory->packs[i].inventory = inventory;
-            inventory->packs[i].path = strdup(json_string_value(path));
-            inventory->packs[i].publisher = strdup(json_string_value(publisher));
-            inventory->packs[i].package = strdup(json_string_value(name));
-            inventory->packs[i].platform = strdup(json_string_value(platform));
-            inventory->packs[i].arch = strdup(json_string_value(architecture));
-            inventory->packs[i].channel = strdup(json_string_value(channel));
+            inventory->packs[i].path = platform_strdup(json_string_value(path));
+            inventory->packs[i].publisher = platform_strdup(json_string_value(publisher));
+            inventory->packs[i].package = platform_strdup(json_string_value(name));
+            inventory->packs[i].platform = platform_strdup(json_string_value(platform));
+            inventory->packs[i].arch = platform_strdup(json_string_value(architecture));
+            inventory->packs[i].channel = platform_strdup(json_string_value(channel));
             inventory->packs[i].version.major = json_integer_value(version_major);
             inventory->packs[i].version.minor = json_integer_value(version_minor);
             inventory->packs[i].version.patch = json_integer_value(version_patch);
@@ -225,7 +225,7 @@ int inventory_load(const char* path, struct fridge_inventory** inventoryOut)
     VLOG_TRACE("inventory", "inventory loaded, %i packs available\n", inventory->packs_count);
 
     // store the base path of the inventory
-    inventory->path = strdup(path);
+    inventory->path = platform_strdup(path);
     *inventoryOut = inventory;
     return 0;
 }
@@ -324,19 +324,19 @@ int inventory_add(struct fridge_inventory* inventory, const char* packPath, cons
     memset(packEntry, 0, sizeof(struct fridge_inventory_pack));
 
     packEntry->inventory = inventory;
-    packEntry->path      = strdup(packPath);
-    packEntry->publisher = strdup(publisher);
-    packEntry->package   = strdup(package);
-    packEntry->platform  = platform != NULL ? strdup(platform) : NULL;
-    packEntry->arch      = platform != NULL ? strdup(arch) : NULL;
-    packEntry->channel   = strdup(channel);
+    packEntry->path      = platform_strdup(packPath);
+    packEntry->publisher = platform_strdup(publisher);
+    packEntry->package   = platform_strdup(package);
+    packEntry->platform  = platform != NULL ? platform_strdup(platform) : NULL;
+    packEntry->arch      = platform != NULL ? platform_strdup(arch) : NULL;
+    packEntry->channel   = platform_strdup(channel);
 
     packEntry->version.major = version->major;
     packEntry->version.minor = version->minor;
     packEntry->version.patch = version->patch;
     packEntry->version.revision = version->revision;
     if (version->tag) {
-        packEntry->version.tag = strdup(version->tag);
+        packEntry->version.tag = platform_strdup(version->tag);
     }
 
     *packOut = packEntry;

--- a/libs/fridge/inventory.c
+++ b/libs/fridge/inventory.c
@@ -300,7 +300,6 @@ int inventory_add(struct fridge_inventory* inventory, const char* packPath, cons
     struct fridge_inventory_pack* packEntry;
     void*                         newArray;
     void*                         oldArray;
-    int                           status;
 
     if (inventory == NULL || publisher == NULL || 
         package == NULL   || channel == NULL) {

--- a/libs/fridge/store.c
+++ b/libs/fridge/store.c
@@ -68,8 +68,8 @@ static struct fridge_store* __store_new(const char* platform, const char* arch)
         return NULL;
     }
     memset(store, 0, sizeof(struct fridge_store));
-    store->platform = strdup(platform);
-    store->arch = strdup(arch);
+    store->platform = platform_strdup(platform);
+    store->arch = platform_strdup(arch);
     return store;
 }
 
@@ -245,7 +245,7 @@ static int __store_download(
     }
 
     if (pathOut != NULL) {
-        *pathOut = strdup(&pathBuffer[0]);
+        *pathOut = platform_strdup(&pathBuffer[0]);
     }
     
     *revisionDownloaded = downloadParams.revision;

--- a/libs/ingredient/ingredient.c
+++ b/libs/ingredient/ingredient.c
@@ -130,7 +130,7 @@ static int __handle_options(struct VaFs* vafsHandle, struct ingredient* ingredie
     data = (char*)options + sizeof(struct chef_vafs_feature_ingredient_opts);
 
 #define READ_IF_PRESENT(__MEM) if (options->__MEM ## _length > 0) { \
-        char* line = strndup(data, options->__MEM ## _length); \
+        char* line = platform_strndup(data, options->__MEM ## _length); \
         ingredient->options->__MEM = strsplit(line, ','); \
         data += options->__MEM ## _length; \
         free(line); \
@@ -174,7 +174,6 @@ int ingredient_open(const char* path, struct ingredient** ingredientOut)
 {
     struct VaFs*           vafsHandle;
     struct ingredient*     ingredient;
-    enum chef_package_type packType;
     int                    status;
 
     ingredient = __ingredient_new();
@@ -250,7 +249,6 @@ static int __extract_file(
     FILE* file;
     long  fileSize;
     void* fileBuffer;
-    int   status;
 
     if ((file = fopen(path, "wb+")) == NULL) {
         fprintf(stderr, "__extract_file: unable to open file %s\n", path);

--- a/libs/kitchen/include/chef/kitchen.h
+++ b/libs/kitchen/include/chef/kitchen.h
@@ -84,6 +84,7 @@ struct kitchen {
     // external paths that point inside chroot
     // i.e paths valid outside chroot
     char* host_chroot;
+    char* host_kitchen_project_root;
     char* host_build_path;
     char* host_build_ingredients_path;
     char* host_build_toolchains_path;

--- a/libs/kitchen/include/chef/recipe.h
+++ b/libs/kitchen/include/chef/recipe.h
@@ -180,6 +180,8 @@ struct recipe_cache_package_change {
 extern int         recipe_cache_initialize(struct recipe* current, const char* cwd);
 extern const char* recipe_cache_uuid(void);
 extern const char* recipe_cache_uuid_for(const char* name);
+extern void        recipe_cache_transaction_begin(void);
+extern void        recipe_cache_transaction_commit(void);
 
 extern int recipe_cache_calculate_package_changes(struct recipe_cache_package_change** changes, int* changeCount);
 extern int recipe_cache_commit_package_changes(struct recipe_cache_package_change* changes, int count);

--- a/libs/kitchen/include/chef/recipe.h
+++ b/libs/kitchen/include/chef/recipe.h
@@ -177,7 +177,7 @@ struct recipe_cache_package_change {
     const char*                   name;
 };
 
-extern int         recipe_cache_initialize(struct recipe* current);
+extern int         recipe_cache_initialize(struct recipe* current, const char* cwd);
 extern const char* recipe_cache_uuid(void);
 extern const char* recipe_cache_uuid_for(const char* name);
 

--- a/libs/kitchen/linux/kitchen.c
+++ b/libs/kitchen/linux/kitchen.c
@@ -67,7 +67,7 @@ static int __is_mountpoint(const char* path)
 
 static int __ensure_mounted_dirs(struct kitchen* kitchen, const char* projectPath)
 {
-    char buff[2048];
+    char buff[PATH_MAX];
     VLOG_DEBUG("kitchen", "__ensure_mounted_dirs()\n");
     
     if (__is_mountpoint(kitchen->host_install_root) == 0) {
@@ -96,7 +96,7 @@ static int __ensure_mounted_dirs(struct kitchen* kitchen, const char* projectPat
 
 static int __ensure_mounts_cleanup(const char* chroot)
 {
-    char buff[2048];
+    char buff[PATH_MAX];
     VLOG_DEBUG("kitchen", "__ensure_mounts_cleanup()\n");
 
     snprintf(&buff[0], sizeof(buff), "%s/chef/install", chroot);
@@ -174,7 +174,7 @@ static int __setup_toolchains(struct list* ingredients, const char* hostPath)
 {
     struct list_item* i;
     int               status;
-    char              buff[512];
+    char              buff[PATH_MAX];
 
     if (ingredients == NULL) {
         return 0;
@@ -363,7 +363,7 @@ static void __debootstrap_output_handler(const char* line, enum platform_spawn_o
 
 static int __setup_environment(int confined, const char* path)
 {
-    char  scratchPad[1024];
+    char  scratchPad[PATH_MAX];
     int   status;
     pid_t child, wt;
     VLOG_DEBUG("kitchen", "__setup_environment(confined=%i, path=%s)\n", confined, path);
@@ -414,7 +414,7 @@ static int __perform_package_operations(void* context)
 {
     struct recipe_cache_package_change* changes;
     int                                 count;
-    char                                scratchPad[4096];
+    char                                scratchPad[PATH_MAX];
     char*                               aptpkgs;
     int                                 status;
     (void)context;
@@ -703,7 +703,7 @@ cleanup:
 
 static int __recipe_clean(const char* uuid)
 {
-    char root[2048] = { 0 };
+    char root[PATH_MAX] = { 0 };
     int  status;
 
     status = __get_kitchen_root(&root[0], sizeof(root) - 1, uuid);
@@ -738,7 +738,7 @@ int kitchen_purge(struct kitchen_purge_options* options)
     struct list         recipes;
     struct list_item*   i;
     int                 status;
-    char                root[2048] = { 0 };
+    char                root[PATH_MAX] = { 0 };
     VLOG_DEBUG("kitchen", "kitchen_purge()\n");
 
     status = __get_kitchen_root(&root[0], sizeof(root) - 1, NULL);

--- a/libs/kitchen/linux/kitchen_init.c
+++ b/libs/kitchen/linux/kitchen_init.c
@@ -107,6 +107,9 @@ static int __kitchen_construct(struct kitchen_init_options* options, struct kitc
     kitchen->real_project_path = strdup(options->project_path);
     kitchen->confined = options->confined;
     kitchen->magic = __KITCHEN_INIT_MAGIC;
+    kitchen->recipe = options->recipe;
+
+    kitchen->host_kitchen_project_root = strdup(&root[0]);
 
     snprintf(&buff[0], sizeof(buff), "%s/output", &root[0]);
     kitchen->shared_output_path = strdup(&buff[0]);

--- a/libs/kitchen/linux/kitchen_init.c
+++ b/libs/kitchen/linux/kitchen_init.c
@@ -61,7 +61,7 @@ static struct pkgmngr* __setup_pkg_environment(struct kitchen_init_options* opti
 
 int __get_kitchen_root(char* buffer, size_t maxLength, const char* uuid)
 {
-    char root[2048];
+    char root[PATH_MAX];
     int  status;
 
     status = platform_getuserdir(&root[0], sizeof(root));
@@ -90,8 +90,8 @@ int __get_kitchen_root(char* buffer, size_t maxLength, const char* uuid)
 // <root>/.kitchen/<recipe>/chef/project => <root>
 static int __kitchen_construct(struct kitchen_init_options* options, struct kitchen* kitchen)
 {
-    char buff[4096];
-    char root[2048] = { 0 };
+    char buff[PATH_MAX*2];
+    char root[PATH_MAX] = { 0 };
     int  status;
     VLOG_DEBUG("kitchen", "__kitchen_construct(name=%s)\n", options->recipe->project.name);
 
@@ -175,7 +175,7 @@ int kitchen_initialize(struct kitchen_init_options* options, struct kitchen* kit
         return -1;
     }
     
-    if (recipe_cache_initialize(options->recipe)) {
+    if (recipe_cache_initialize(options->recipe, options->project_path)) {
         VLOG_ERROR("kitchen", "failed to initialize recipe cache\n");
         return -1;
     }

--- a/libs/kitchen/linux/kitchen_step_clean.c
+++ b/libs/kitchen/linux/kitchen_step_clean.c
@@ -137,6 +137,7 @@ int kitchen_recipe_clean(struct kitchen* kitchen)
         goto cleanup;
     }
 
+    recipe_cache_transaction_begin();
     list_foreach(&kitchen->recipe->parts, item) {
         struct recipe_part* part = (struct recipe_part*)item;
         
@@ -146,6 +147,7 @@ int kitchen_recipe_clean(struct kitchen* kitchen)
             break;
         }
     }
+    recipe_cache_transaction_commit();
 
 cleanup:
     kitchen_user_delete(&user);

--- a/libs/kitchen/linux/kitchen_step_make.c
+++ b/libs/kitchen/linux/kitchen_step_make.c
@@ -119,6 +119,7 @@ int kitchen_recipe_make(struct kitchen* kitchen, struct recipe* recipe)
         return -1;
     }
 
+    recipe_cache_transaction_begin();
     status = kitchen_cooking_start(kitchen);
     if (status) {
         VLOG_ERROR("kitchen", "kitchen_recipe_make: failed to start cooking: %i\n", status);
@@ -159,8 +160,7 @@ int kitchen_recipe_make(struct kitchen* kitchen, struct recipe* recipe)
         }
     }
 
-    status = kitchen_user_regain_privs(&user);
-    if (status) {
+    if (kitchen_user_regain_privs(&user)) {
         VLOG_ERROR("kitchen", "kitchen_recipe_make: failed to re-escalate privileges\n");
     }
 
@@ -168,6 +168,7 @@ cleanup:
     if (kitchen_cooking_end(kitchen)) {
         VLOG_ERROR("kitchen", "kitchen_recipe_make: failed to end cooking\n");
     }
+    recipe_cache_transaction_commit();
     kitchen_user_delete(&user);
     return status;
 }

--- a/libs/kitchen/recipe.c
+++ b/libs/kitchen/recipe.c
@@ -161,7 +161,7 @@ static const char* __parse_string(const char* value)
         return NULL;
     }
 
-    return strdup(value);
+    return platform_strdup(value);
 }
 
 static enum chef_package_type __parse_pack_type(const char* value)
@@ -618,7 +618,7 @@ static void __finalize_meson_wrap_item(struct parser_state* state)
             exit(EXIT_FAILURE); \
         } \
         \
-        argument->value = strdup(value); \
+        argument->value = platform_strdup(value); \
         \
         list_add(&state->_stname._field, &argument->list_header); \
     }

--- a/libs/kitchen/recipe_cache.c
+++ b/libs/kitchen/recipe_cache.c
@@ -46,7 +46,7 @@ static struct recipe_cache_package* __parse_recipe_cache_package(const json_t* p
         free(pkg);
         return NULL;
     }
-    pkg->name = strdup(json_string_value(member));
+    pkg->name = platform_strdup(json_string_value(member));
     return pkg;
 }
 
@@ -71,7 +71,7 @@ static struct recipe_cache_package* __new_recipe_cache_package(const char* name)
     }
     memset(pkg, 0, sizeof(struct recipe_cache_package));
     
-    pkg->name = strdup(name);
+    pkg->name = platform_strdup(name);
     if (pkg->name == NULL) {
         free(pkg);
         return NULL;
@@ -106,7 +106,7 @@ static struct recipe_cache_ingredient* __parse_recipe_cache_ingredient(const jso
         free(ing);
         return NULL;
     }
-    ing->name = strdup(json_string_value(member));
+    ing->name = platform_strdup(json_string_value(member));
     return ing;
 }
 
@@ -164,8 +164,8 @@ static int __construct_recipe_cache_item(struct recipe_cache_item* cacheItem, co
 
     memset(cacheItem, 0, sizeof(struct recipe_cache_item));
     __generate_cache_uuid(&uuid[0]);
-    cacheItem->name = strdup(name);
-    cacheItem->uuid = strdup(&uuid[0]);
+    cacheItem->name = platform_strdup(name);
+    cacheItem->uuid = platform_strdup(&uuid[0]);
     cacheItem->keystore = json_object();
     if (cacheItem->name == NULL || cacheItem->uuid == NULL || cacheItem->keystore == NULL) {
         free((void*)cacheItem->name);
@@ -186,13 +186,13 @@ static int __parse_cache_item(struct recipe_cache_item* cacheItem, json_t* root)
     if (member == NULL) {
         return -1;
     }
-    cacheItem->name = strdup(json_string_value(member));
+    cacheItem->name = platform_strdup(json_string_value(member));
 
     member = json_object_get(root, "uuid");
     if (member == NULL) {
         return -1;
     }
-    cacheItem->uuid = strdup(json_string_value(member));
+    cacheItem->uuid = platform_strdup(json_string_value(member));
 
     cacheItem->keystore = json_object_get(root, "cache");
     if (cacheItem->keystore == NULL) {
@@ -354,7 +354,7 @@ static int __parse_cache(struct recipe_cache* cache, json_t* root)
 static int __initialize_cache(struct recipe_cache* cache, const char* path)
 {
     memset(cache, 0, sizeof(struct recipe_cache));
-    cache->path = strdup(path);
+    cache->path = platform_strdup(path);
     if (cache->path == NULL) {
         return -1;
     }

--- a/libs/kitchen/recipe_cache.c
+++ b/libs/kitchen/recipe_cache.c
@@ -406,7 +406,7 @@ static json_t* __serialize_cache(struct recipe_cache* cache)
             VLOG_ERROR("cache", "__serialize_cache: failed to serialize cache for %s\n", cache->items[i].name);
             return NULL;
         }
-        json_array_append_new(root, item);
+        json_array_append_new(items, item);
     }
 
     json_object_set_new(root, "caches", items);

--- a/libs/kitchen/recipe_utils.c
+++ b/libs/kitchen/recipe_utils.c
@@ -32,8 +32,8 @@ int recipe_parse_platform_toolchain(const char* toolchain, char** ingredient, ch
     
     split = strchr(toolchain, '=');
     if (split == NULL) {
-        *ingredient = strdup(toolchain);
-        *channel = strdup("stable");
+        *ingredient = platform_strdup(toolchain);
+        *channel = platform_strdup("stable");
         *version = NULL;
         return 0;
     }
@@ -41,14 +41,14 @@ int recipe_parse_platform_toolchain(const char* toolchain, char** ingredient, ch
     strncpy(&name[0], toolchain, __MIN((split - toolchain), sizeof(name)));
     strncpy(&verr[0], split+1, sizeof(verr));
 
-    *ingredient = strdup(&name[0]);
+    *ingredient = platform_strdup(&name[0]);
     // If the first character is a digit, assume version, installing by version
     // always tracks stable
     if (isdigit(verr[0])) {
-        *channel = strdup("stable");
-        *version = strdup(&verr[0]);
+        *channel = platform_strdup("stable");
+        *version = platform_strdup(&verr[0]);
     } else {
-        *channel = strdup(&verr[0]);
+        *channel = platform_strdup(&verr[0]);
         *version = NULL;
     }
     return 0;

--- a/libs/oven/backends/generators/autotools.c
+++ b/libs/oven/backends/generators/autotools.c
@@ -98,7 +98,7 @@ static char* __replace_or_add_prefix(const char* platform, const char* arguments
         endOfValue = strchr(startOfValue, '\0');
     }
 
-    oldPath      = strndup(startOfValue, endOfValue - startOfValue);
+    oldPath      = platform_strndup(startOfValue, endOfValue - startOfValue);
     newArguments = malloc(strlen(arguments) + 1024);
     if (oldPath == NULL|| newArguments == NULL) {
         free(oldPath);

--- a/libs/oven/backends/generators/cmake.c
+++ b/libs/oven/backends/generators/cmake.c
@@ -54,7 +54,7 @@ static int __write_header(FILE* file, const char* projectName, const char* profi
 {
     char* cmake;
 
-    cmake = strdup(g_cmakeTemplate);
+    cmake = platform_strdup(g_cmakeTemplate);
     if (cmake == NULL) {
         errno = ENOMEM;
         return -1;
@@ -180,7 +180,7 @@ static char* __replace_install_prefix(const char* previousValue, const char* pla
         return strpathcombine(paths->install, previousValue);
     }
     // it seems this was set up correctly by the recipe, let it be
-    return strdup(previousValue);
+    return platform_strdup(previousValue);
 }
 
 static void __add_default_prefix_paths(char* output, const char* platform, const char* buildIngredientsRoot)
@@ -206,7 +206,7 @@ static char* __replace_path_prefix(const char* previousValue, const char* platfo
     // Expect generally that people don't modify this
     if (previousValue == NULL) {
         __add_default_prefix_paths(&tmp[0], platform, paths->build_ingredients);
-        return strdup(&tmp[0]);
+        return platform_strdup(&tmp[0]);
     }
 
     // However if they do, let us produce a modified version
@@ -214,7 +214,7 @@ static char* __replace_path_prefix(const char* previousValue, const char* platfo
     length = strlen(tmp);
     tmp[length++] = ';';
     __add_default_prefix_paths(&tmp[length], platform, paths->build_ingredients);
-    return strdup(&tmp[0]);
+    return platform_strdup(&tmp[0]);
 }
 
 static char* __extract_cmake_option_value(const char* startOfOption)
@@ -232,7 +232,7 @@ static char* __extract_cmake_option_value(const char* startOfOption)
             return NULL;
         }
     }
-    return strndup(startOfValue, endOfValue - startOfValue);
+    return platform_strndup(startOfValue, endOfValue - startOfValue);
 }
 
 static void __replace_cmake_option_value(char* arguments, const char* option, const char* value)
@@ -272,7 +272,7 @@ static void __replace_cmake_option_value(char* arguments, const char* option, co
         memcpy(&arguments[optionValueStartIndex], value, newLength);
     } else {
         // new length is longer, we need to move it, then replace
-        char* remaining = strdup(&arguments[optionValueEndIndex]);
+        char* remaining = platform_strdup(&arguments[optionValueEndIndex]);
         if (remaining == NULL) {
             VLOG_ERROR("cmake", "failed to replace option %s with %s\n", option, value);
             return;

--- a/libs/oven/backends/generators/meson.c
+++ b/libs/oven/backends/generators/meson.c
@@ -65,7 +65,6 @@ static int __read_file(const char* path, char** bufferOut)
 static int __write_file(const char* path, const char* buffer)
 {
     FILE* file;
-    int   status;
 
     file = fopen(path, "w");
     if (file == NULL) {

--- a/libs/oven/commands.c
+++ b/libs/oven/commands.c
@@ -77,8 +77,8 @@ static int __resolve_dependency_path(struct oven_resolve* resolve, struct oven_r
     list_foreach(&files, item) {
         struct platform_file_entry* file = (struct platform_file_entry*)item;
         if (!strcmp(file->name, dependency->name)) {
-            dependency->path = strdup(file->path);
-            dependency->sub_path = strdup(file->sub_path);
+            dependency->path = platform_strdup(file->path);
+            dependency->sub_path = platform_strdup(file->sub_path);
             platform_getfiles_destroy(&files);
             return 0;
         }

--- a/libs/oven/container.c
+++ b/libs/oven/container.c
@@ -329,7 +329,6 @@ static int __write_syslib(
     struct oven_resolve_dependency* dependency)
 {
     struct VaFsDirectoryHandle* subdirectoryHandle;
-    struct list_item*           item;
     int                         status;
 
     // write library directories as rwxr-xr-x

--- a/libs/oven/container.c
+++ b/libs/oven/container.c
@@ -375,7 +375,7 @@ static int __write_filepath(
         return 0;
     }
 
-    token = strndup(remainingPath, remaining - remainingPath);
+    token = platform_strndup(remainingPath, remaining - remainingPath);
     if (!token) {
         return -1;
     }
@@ -1006,13 +1006,13 @@ static int __build_pack_names(const char* name, const char* imageDir, char** bas
     char tmp[4096];
 
     strbasename(name, &tmp[0], sizeof(tmp));
-    *basenameOut = strdup(&tmp[0]);
+    *basenameOut = platform_strdup(&tmp[0]);
     if (*basenameOut == NULL) {
         return -1;
     }
 
     snprintf(&tmp[0], sizeof(tmp), "%s/%s.pack", imageDir, *basenameOut);
-    *imagePathOut = strdup(&tmp[0]);
+    *imagePathOut = platform_strdup(&tmp[0]);
     if (*basenameOut == NULL) {
         free(*basenameOut);
         return -1;

--- a/libs/oven/oven.c
+++ b/libs/oven/oven.c
@@ -651,7 +651,6 @@ int oven_configure(struct oven_generate_options* options)
     struct generate_backend* backend;
     struct oven_backend_data data;
     int                      status;
-    char*                    path;
 
     if (!options) {
         errno = EINVAL;

--- a/libs/oven/oven.c
+++ b/libs/oven/oven.c
@@ -103,15 +103,15 @@ int oven_initialize(struct oven_parameters* parameters)
     }
 
     // copy relevant paths
-    g_oven.paths.project_root = strdup(parameters->paths.project_root);
-    g_oven.paths.build_root = strdup(parameters->paths.build_root);
-    g_oven.paths.install_root = strdup(parameters->paths.install_root);
-    g_oven.paths.toolchains_root = strdup(parameters->paths.toolchains_root);
-    g_oven.paths.build_ingredients_root = strdup(parameters->paths.build_ingredients_root);
+    g_oven.paths.project_root = platform_strdup(parameters->paths.project_root);
+    g_oven.paths.build_root = platform_strdup(parameters->paths.build_root);
+    g_oven.paths.install_root = platform_strdup(parameters->paths.install_root);
+    g_oven.paths.toolchains_root = platform_strdup(parameters->paths.toolchains_root);
+    g_oven.paths.build_ingredients_root = platform_strdup(parameters->paths.build_ingredients_root);
     
     // update oven variables
-    g_oven.variables.target_platform = strdup(parameters->target_platform);
-    g_oven.variables.target_arch     = strdup(parameters->target_architecture);
+    g_oven.variables.target_platform = platform_strdup(parameters->target_platform);
+    g_oven.variables.target_arch     = platform_strdup(parameters->target_architecture);
 
     // update oven context
     g_oven.process_environment = parameters->envp;
@@ -158,7 +158,7 @@ int oven_recipe_start(struct oven_recipe_options* options)
         errno = ENOSYS;
         return -1;
     }
-    g_oven.recipe.name = strdup(options->name);
+    g_oven.recipe.name = platform_strdup(options->name);
 
     // construct the recipe paths
     g_oven.recipe.source_root = strpathcombine(g_oven.paths.project_root, options->relative_path);
@@ -245,7 +245,7 @@ static int __expand_variable(char** at, char** buffer, int* index, size_t* maxLe
         }
         end++;
         
-        variable = strndup(start, end - start);
+        variable = platform_strndup(start, end - start);
         if (variable != NULL) {
             const char* value = __get_variable(variable);
             free(variable);
@@ -297,7 +297,7 @@ static int __expand_environment_variable(char** at, char** buffer, int* index, s
         }
         end++;
 
-        variable = strndup(start, end - start);
+        variable = platform_strndup(start, end - start);
         if (variable != NULL) {
             char* value = getenv(variable);
             free(variable);
@@ -404,7 +404,7 @@ char* oven_preprocess_text(const char* original)
         }
     }
     
-    result = strdup(buffer);
+    result = platform_strdup(buffer);
     free(buffer);
     return result;
 }
@@ -465,7 +465,7 @@ static struct chef_keypair_item* __preprocess_keypair(struct chef_keypair_item* 
         return NULL;
     }
 
-    keypair->key   = strdup(original->key);
+    keypair->key   = platform_strdup(original->key);
     keypair->value = oven_preprocess_text(original->value);
     return keypair;
 }
@@ -516,11 +516,11 @@ static struct chef_keypair_item* __compose_keypair(const char* key, const char* 
     if (item == NULL) {
         return NULL;
     }
-    item->key = strdup(key);
+    item->key = platform_strdup(key);
     if (item->key == NULL) {
         free(item);
     }
-    item->value = strdup(value);
+    item->value = platform_strdup(value);
     if (item->value == NULL) {
         free((void*)item->key);
         free(item);

--- a/libs/oven/pkgmgrs/pkg-config.c
+++ b/libs/oven/pkgmgrs/pkg-config.c
@@ -265,7 +265,6 @@ struct pkgmngr* pkgmngr_pkgconfig_new(struct pkgmngr_options* options)
 {
     struct pkgconfig* pkgconfig;
     char              tmp[2048];
-    int               status;
     VLOG_DEBUG("pkg-config", "pkgmngr_pkgconfig_new(root=%s)\n", options->root);
 
     pkgconfig = malloc(sizeof(struct pkgconfig));

--- a/libs/oven/pkgmgrs/pkg-config.c
+++ b/libs/oven/pkgmgrs/pkg-config.c
@@ -189,11 +189,11 @@ static struct chef_keypair_item* __compose_keypair(const char* key, const char* 
     if (item == NULL) {
         return NULL;
     }
-    item->key = strdup(key);
+    item->key = platform_strdup(key);
     if (item->key == NULL) {
         free(item);
     }
-    item->value = strdup(value);
+    item->value = platform_strdup(value);
     if (item->value == NULL) {
         free((void*)item->key);
         free(item);
@@ -222,7 +222,7 @@ static int __add_or_replace_pkgconfig_paths(struct pkgmngr* pkgmngr, struct list
         for (int i = 0; idents[i].ident != NULL; i++) {
             if (!strcmp(keypair->key, idents[i].ident)) {
                 const char* tmp = keypair->value;
-                keypair->value = strdup(__get_pcroot2(pkgconfig));
+                keypair->value = platform_strdup(__get_pcroot2(pkgconfig));
                 if (keypair->value == NULL) {
                     keypair->value = tmp;
                     return -1;
@@ -278,19 +278,19 @@ struct pkgmngr* pkgmngr_pkgconfig_new(struct pkgmngr_options* options)
     pkgconfig->base.destroy        = __destroy;
 
     // build roots
-    pkgconfig->root = strdup("/");
+    pkgconfig->root = platform_strdup("/");
     snprintf(&tmp[0], sizeof(tmp), "/chef/ingredients/%s/%s/", options->target_platform, options->target_architecture);
-    pkgconfig->ccroot = strdup(&tmp[0]);
+    pkgconfig->ccroot = platform_strdup(&tmp[0]);
 
     // build pcroots
     snprintf(&tmp[0], sizeof(tmp), "%s/usr/share/pkgconfig/", options->root);
-    pkgconfig->pcroot = strdup(&tmp[0]);
+    pkgconfig->pcroot = platform_strdup(&tmp[0]);
     snprintf(&tmp[0], sizeof(tmp), "%s/chef/ingredients/%s/%s/pkgconfig/", options->root, options->target_platform, options->target_architecture);
-    pkgconfig->ccpcroot = strdup(&tmp[0]);
+    pkgconfig->ccpcroot = platform_strdup(&tmp[0]);
 
     // copy system info
-    pkgconfig->target_platform = strdup(options->target_platform);
-    pkgconfig->target_architecture = strdup(options->target_architecture);
+    pkgconfig->target_platform = platform_strdup(options->target_platform);
+    pkgconfig->target_architecture = platform_strdup(options->target_architecture);
 
     return &pkgconfig->base;
 }

--- a/libs/oven/resolvers/common.c
+++ b/libs/oven/resolvers/common.c
@@ -16,6 +16,7 @@
  * 
  */
 
+#include <chef/platform.h>
 #include "resolvers.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/libs/oven/resolvers/common.c
+++ b/libs/oven/resolvers/common.c
@@ -40,7 +40,7 @@ int __resolve_add_dependency(struct list* dependencies, const char* library)
         return -1;
     }
 
-    dependency->name = strdup(library);
+    dependency->name = platform_strdup(library);
     if (dependency->name == NULL) {
         free(dependency);
         return -1;

--- a/libs/oven/resolvers/linux.c
+++ b/libs/oven/resolvers/linux.c
@@ -81,7 +81,7 @@ static int __get_ld_conf_paths(const char* path, struct list* paths)
             break;
         }
 
-        entry->path = strdup(buffer);
+        entry->path = platform_strdup(buffer);
         list_add(paths, &entry->list_header);
     }
     

--- a/libs/oven/resolvers/pe.c
+++ b/libs/oven/resolvers/pe.c
@@ -185,12 +185,11 @@ static enum oven_resolve_arch __pe_machine_to_arch(uint16_t pe_arch)
 
 int pe_is_valid(const char* path, enum oven_resolve_arch* arch)
 {
-    MzHeader*         mz;
-    PeHeader*         pe;
-    PeOptionalHeader* optional;
-    FILE*             file;
-    size_t            read;
-    char              buffer[0x200];
+    MzHeader* mz;
+    PeHeader* pe;
+    FILE*     file;
+    size_t    read;
+    char      buffer[0x200];
 
     file = fopen(path, "rb");
     if (file == NULL) {

--- a/libs/oven/utils/environment.c
+++ b/libs/oven/utils/environment.c
@@ -61,7 +61,7 @@ char** oven_environment_create(const char* const* parent, struct list* additiona
     // list, as we want to use that one instead
     while (parent[i]) {
         if (!__contains_envkey(additional, parent[i])) {
-            environment[j++] = strdup(parent[i]);
+            environment[j++] = platform_strdup(parent[i]);
         }
         i++;
     }

--- a/libs/platform/include/chef/platform.h
+++ b/libs/platform/include/chef/platform.h
@@ -130,6 +130,8 @@ typedef SSIZE_T ssize_t;
 #include <Windows.h>
 #undef PATH_MAX
 #define PATH_MAX MAX_PATH
+#elif __linux__
+#include <linux/limits.h>
 #else
 #include <limits.h>
 #endif

--- a/libs/platform/include/chef/platform.h
+++ b/libs/platform/include/chef/platform.h
@@ -229,6 +229,8 @@ extern int platform_cpucount(void);
 extern int platform_copyfile(const char* source, const char* destination);
 extern int platform_lockfile(int fd);
 extern int platform_unlockfile(int fd);
+extern char* platform_strdup(const char* string);
+extern char* platform_strndup(const char* string, size_t maxlen);
 
 /**
  * @brief 

--- a/libs/platform/ioutils/getfiles.c
+++ b/libs/platform/ioutils/getfiles.c
@@ -79,6 +79,9 @@ static int __read_directory(const char* path, const char* subPath, int recursive
     }
 
     if ((d = opendir(path)) == NULL) {
+        if (errno == ENOENT) {
+            return 0;
+        }
         return -1;
     }
 

--- a/libs/platform/ioutils/getfiles.c
+++ b/libs/platform/ioutils/getfiles.c
@@ -37,9 +37,9 @@ static int __add_file(const struct dirent* dp, const char* path, const char* sub
         return -1;
     }
 
-    entry->name     = strdup(dp->d_name);
-    entry->path     = strdup(path);
-    entry->sub_path = subPath != NULL ? strdup(subPath) : NULL;
+    entry->name     = platform_strdup(dp->d_name);
+    entry->path     = platform_strdup(path);
+    entry->sub_path = subPath != NULL ? platform_strdup(subPath) : NULL;
     if (entry->name == NULL || entry->path == NULL) {
         free(entry->name);
         free(entry->path);

--- a/libs/platform/osutils/linux/CMakeLists.txt
+++ b/libs/platform/osutils/linux/CMakeLists.txt
@@ -14,6 +14,8 @@ add_library(platform-osutils STATIC
     sleep.c
     spawn.c
     stat.c
+    strdup.c
+    strndup.c
     symlink.c
     unlink.c
 )

--- a/libs/platform/osutils/linux/strdup.c
+++ b/libs/platform/osutils/linux/strdup.c
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2022, Philip Meulengracht
+ *
+ * This program is free software : you can redistribute it and / or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation ? , either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ */
+
+#include <chef/platform.h>
+#include <string.h>
+
+char* platform_strdup(const char* string)
+{
+    return strdup(string);
+}

--- a/libs/platform/osutils/linux/strndup.c
+++ b/libs/platform/osutils/linux/strndup.c
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2022, Philip Meulengracht
+ *
+ * This program is free software : you can redistribute it and / or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation ? , either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ */
+
+#include <chef/platform.h>
+#include <string.h>
+
+char* platform_strndup(const char* string, size_t maxlen)
+{
+    return strndup(string, maxlen);
+}

--- a/libs/platform/osutils/windows/CMakeLists.txt
+++ b/libs/platform/osutils/windows/CMakeLists.txt
@@ -1,7 +1,11 @@
 add_library(platform-osutils STATIC
     abspath.c
-    chsize.c    
+    chsize.c   
+    cpucount.c 
     exec.c  
+    getcwd.c
+    getuserdir.c
+    mkdir.c  
     sleep.c   
     unlink.c 
 )

--- a/libs/platform/osutils/windows/CMakeLists.txt
+++ b/libs/platform/osutils/windows/CMakeLists.txt
@@ -1,12 +1,14 @@
 add_library(platform-osutils STATIC
     abspath.c
-    chsize.c   
-    cpucount.c 
-    exec.c  
+    chsize.c
+    cpucount.c
+    exec.c
     getcwd.c
     getuserdir.c
-    mkdir.c  
-    sleep.c   
-    unlink.c 
+    mkdir.c
+    sleep.c
+    strdup.c
+    strndup.c
+    unlink.c
 )
 target_include_directories(platform-osutils PRIVATE ../../include)

--- a/libs/platform/osutils/windows/abspath.c
+++ b/libs/platform/osutils/windows/abspath.c
@@ -21,15 +21,18 @@
 
 char* platform_abspath(const char* path)
 {
-    char *fullPath = calloc(1, MAX_PATH);
+    char* fullPath;
+    DWORD result;
+
+    fullPath = calloc(1, MAX_PATH);
     if (fullPath == NULL) {
         return NULL;
     }
 
-    if (GetFullPathName(path, MAX_PATH, fullPath, NULL) == 0) {
+    result = GetFullPathName(path, MAX_PATH, fullPath, NULL);
+    if (!result) {
         free(fullPath);
         return NULL;
     }
-    
     return fullPath;
 }

--- a/libs/platform/osutils/windows/cpucount.c
+++ b/libs/platform/osutils/windows/cpucount.c
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2024, Philip Meulengracht
+ *
+ * This program is free software : you can redistribute it and / or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation ? , either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ */
+
+#include <chef/platform.h>
+
+int platform_cpucount(void)
+{
+    SYSTEM_INFO sysinfo;
+    GetSystemInfo(&sysinfo);
+    return (int)sysinfo.dwNumberOfProcessors;
+}

--- a/libs/platform/osutils/windows/getcwd.c
+++ b/libs/platform/osutils/windows/getcwd.c
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2024, Philip Meulengracht
+ *
+ * This program is free software : you can redistribute it and / or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation ? , either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ */
+
+#include <chef/platform.h>
+
+int platform_getcwd(char* buffer, size_t length)
+{
+    char* result = _getcwd(buffer, length);
+    if (result == NULL) {
+        return -1;
+    }
+    return 0;
+}

--- a/libs/platform/osutils/windows/getcwd.c
+++ b/libs/platform/osutils/windows/getcwd.c
@@ -17,6 +17,7 @@
  */
 
 #include <chef/platform.h>
+#include <direct.h>
 
 int platform_getcwd(char* buffer, size_t length)
 {

--- a/libs/platform/osutils/windows/getuserdir.c
+++ b/libs/platform/osutils/windows/getuserdir.c
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2024, Philip Meulengracht
+ *
+ * This program is free software : you can redistribute it and / or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation ? , either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ */
+
+#include <chef/platform.h>
+#include <shlobj.h>
+#include <string.h>
+
+int platform_getuserdir(char* buffer, size_t length)
+{
+    PWSTR path = NULL;
+    size_t i;
+    HRESULT hr = SHGetKnownFolderPath(&FOLDERID_LocalAppData, 0, NULL, &path);
+    int result = -1;
+    if (SUCCEEDED(hr)) {
+        wcstombs_s(&i, buffer, length, path, length - 1);
+        result = 0;
+    }
+    // Memory must be freed also when call fails
+    CoTaskMemFree((LPVOID)path);
+    return result;
+}

--- a/libs/platform/osutils/windows/getuserdir.c
+++ b/libs/platform/osutils/windows/getuserdir.c
@@ -22,14 +22,16 @@
 
 int platform_getuserdir(char* buffer, size_t length)
 {
-    PWSTR path = NULL;
-    size_t i;
+    size_t  i;
+    PWSTR   path = NULL;
     HRESULT hr = SHGetKnownFolderPath(&FOLDERID_LocalAppData, 0, NULL, &path);
-    int result = -1;
+    int     result = -1;
+    
     if (SUCCEEDED(hr)) {
         wcstombs_s(&i, buffer, length, path, length - 1);
         result = 0;
     }
+    
     // Memory must be freed also when call fails
     CoTaskMemFree((LPVOID)path);
     return result;

--- a/libs/platform/osutils/windows/mkdir.c
+++ b/libs/platform/osutils/windows/mkdir.c
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2024, Philip Meulengracht
+ *
+ * This program is free software : you can redistribute it and / or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation ? , either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ */
+
+#include <chef/platform.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+
+wchar_t* mb_to_wcs(const char* path) 
+{
+    size_t pathLength = strlen(path);
+    wchar_t* wpath = (wchar_t*)calloc(sizeof(wchar_t), pathLength + 10);
+    if (wpath != NULL) {
+        mbstowcs(wpath, path, pathLength);
+    }
+    return wpath;
+}
+
+int platform_mkdir(const char* path) 
+{
+    wchar_t* wpath = mb_to_wcs(path);
+    if (!wpath) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    size_t length = wcslen(wpath);
+    if (wpath[length - 1] == L'\\' || wpath[length - 1] == L'/') {
+        wpath[length - 1] = L'\0';
+    }
+
+    wchar_t* p;
+    for (wchar_t* p = wpath + 1; *p; p++) {
+        if (*p == L'\\' || *p == L'/') {
+            *p = L'\0';
+            if (_wmkdir(wpath) != 0 && errno != EEXIST) {
+                free(wpath);
+                return -1;
+            }
+            *p = L'\\';
+        }
+    }
+
+    int status = _wmkdir(wpath);
+    if (status != 0 && errno != EEXIST) {
+        free(wpath);
+        return -1;
+    }
+
+    free(wpath);
+    return 0;
+}

--- a/libs/platform/osutils/windows/mkdir.c
+++ b/libs/platform/osutils/windows/mkdir.c
@@ -18,9 +18,10 @@
 
 #include <chef/platform.h>
 #include <errno.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/stat.h>
+#include <wchar.h>
 
 static wchar_t* __mbtowc(const char* path) 
 {

--- a/libs/platform/osutils/windows/strdup.c
+++ b/libs/platform/osutils/windows/strdup.c
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2022, Philip Meulengracht
+ *
+ * This program is free software : you can redistribute it and / or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation ? , either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ */
+
+#include <chef/platform.h>
+#include <string.h>
+
+char* platform_strdup(const char* string)
+{
+    return _strdup(string);
+}

--- a/libs/platform/osutils/windows/strndup.c
+++ b/libs/platform/osutils/windows/strndup.c
@@ -17,7 +17,7 @@
  */
 
 #include <chef/platform.h>
-#include <string.h>
+#include <stdlib.h>
 
 char* platform_strndup(const char* string, size_t maxlen)
 {

--- a/libs/platform/osutils/windows/strndup.c
+++ b/libs/platform/osutils/windows/strndup.c
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2022, Philip Meulengracht
+ *
+ * This program is free software : you can redistribute it and / or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation ? , either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ */
+
+#include <chef/platform.h>
+#include <string.h>
+
+char* platform_strndup(const char* string, size_t maxlen)
+{
+    char* buffer = calloc(1, maxlen+1);
+    if (buffer == NULL) {
+        return NULL;
+    }
+
+    for (int i = 0; ((i < maxlen) && (string[i] != 0)); i++) {
+        buffer[i] = string[i];
+    }
+    return buffer;
+}

--- a/libs/platform/package.c
+++ b/libs/platform/package.c
@@ -17,6 +17,7 @@
  */
 
 #include <chef/package.h>
+#include <chef/platform.h>
 #include <chef/utils_vafs.h>
 #include <errno.h>
 #include <stdlib.h>

--- a/libs/platform/package.c
+++ b/libs/platform/package.c
@@ -49,7 +49,7 @@ static int __load_package_header(struct VaFs* vafs, struct chef_package** packag
     package->type = header->type;
 
 #define READ_IF_PRESENT(__MEM) if (header->__MEM ## _length > 0) { \
-        package->__MEM = strndup(data, header->__MEM ## _length); \
+        package->__MEM = platform_strndup(data, header->__MEM ## _length); \
         data += header->__MEM ## _length; \
     }
 
@@ -96,7 +96,7 @@ static int __load_package_version(struct VaFs* vafs, struct chef_version** versi
     version->revision = header->revision;
 
     if (header->tag_length) {
-        version->tag = strndup(data, header->tag_length);
+        version->tag = platform_strndup(data, header->tag_length);
     }
 
     *versionOut = version;
@@ -113,7 +113,7 @@ static void __fill_command(char** dataPointer, struct chef_command* command)
     *dataPointer += sizeof(struct chef_vafs_package_app);
 
 #define READ_IF_PRESENT(__MEM) if (entry->__MEM ## _length > 0) { \
-        command->__MEM = strndup(*dataPointer, entry->__MEM ## _length); \
+        command->__MEM = platform_strndup(*dataPointer, entry->__MEM ## _length); \
         *dataPointer += entry->__MEM ## _length; \
     }
 

--- a/libs/platform/strutils/strpathcombine.c
+++ b/libs/platform/strutils/strpathcombine.c
@@ -99,18 +99,18 @@ char* strpathcombine(const char* path1, const char* path2)
     }
 
     if (path1 == NULL) {
-        return strdup(path2);
+        return platform_strdup(path2);
     } else if (path2 == NULL) {
-        return strdup(path1);
+        return platform_strdup(path1);
     }
 
     path1Length = strlen(path1);
     path2Length = strlen(path2);
 
     if (path1Length == 0) {
-        return strdup(path2);
+        return platform_strdup(path2);
     } else if (path2Length == 0) {
-        return strdup(path1);
+        return platform_strdup(path1);
     }
 
     if (path2[0] == CHEF_PATH_SEPARATOR) {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vchef
-version: '1.2'
+version: '1.2.1'
 summary: The Vali Chef Package Mangement System
 description: |
   Originally developed for the Vali/MollenOS operating system, this is a generic package management system that is 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory(serve)
 add_subdirectory(serve-exec)
 
 if (CHEF_BUILD_AS_SNAP)
+    # only on linux anyway
     install(
         TARGETS bake order serve serve-exec
         RUNTIME DESTINATION bin
@@ -28,6 +29,9 @@ else()
     if (UNIX)
         install(CODE "execute_process(COMMAND sh -c \"chown root:root $<TARGET_FILE:bake>\" )")
         install(CODE "execute_process(COMMAND sh -c \"chown root:root $<TARGET_FILE:serve-exec>\" )")
+    elseif (WIN32)
+        SET_TARGET_PROPERTIES(bake PROPERTIES LINK_FLAGS "/MANIFESTUAC:\"level='requireAdministrator' uiAccess='false'\" /SUBSYSTEM:CONSOLE")
+        SET_TARGET_PROPERTIES(order-exec PROPERTIES LINK_FLAGS "/MANIFESTUAC:\"level='requireAdministrator' uiAccess='false'\" /SUBSYSTEM:CONSOLE")
     endif()
 endif()
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -31,7 +31,7 @@ else()
         install(CODE "execute_process(COMMAND sh -c \"chown root:root $<TARGET_FILE:serve-exec>\" )")
     elseif (WIN32)
         SET_TARGET_PROPERTIES(bake PROPERTIES LINK_FLAGS "/MANIFESTUAC:\"level='requireAdministrator' uiAccess='false'\" /SUBSYSTEM:CONSOLE")
-        SET_TARGET_PROPERTIES(order-exec PROPERTIES LINK_FLAGS "/MANIFESTUAC:\"level='requireAdministrator' uiAccess='false'\" /SUBSYSTEM:CONSOLE")
+        SET_TARGET_PROPERTIES(serve-exec PROPERTIES LINK_FLAGS "/MANIFESTUAC:\"level='requireAdministrator' uiAccess='false'\" /SUBSYSTEM:CONSOLE")
     endif()
 endif()
 

--- a/tools/bake/commands/clean.c
+++ b/tools/bake/commands/clean.c
@@ -82,7 +82,6 @@ int clean_main(int argc, char** argv, char** envp, struct bake_command_options* 
     int            purge = 0;
     char*          type = "all";
     int            status;
-    char*          cwd;
 
     // handle individual help command
     if (argc > 2) {
@@ -120,7 +119,7 @@ int clean_main(int argc, char** argv, char** envp, struct bake_command_options* 
 
     status = kitchen_initialize(&(struct kitchen_init_options) {
         .recipe = options->recipe,
-        .project_path = cwd,
+        .project_path = options->cwd,
         .pkg_environment = NULL,
         .confined = options->recipe->environment.build.confinement,
         .target_platform = options->platform,

--- a/tools/bake/commands/run.c
+++ b/tools/bake/commands/run.c
@@ -225,8 +225,7 @@ int run_main(int argc, char** argv, char** envp, struct bake_command_options* op
     struct kitchen_init_options  initOptions = { 0 };
     struct kitchen_setup_options setupOptions = { 0 };
     struct kitchen         kitchen;
-    int                    debug    = 0;
-    char*                  cwd;
+    int                    debug = 0;
     int                    status;
 
     // catch CTRL-C
@@ -267,7 +266,7 @@ int run_main(int argc, char** argv, char** envp, struct bake_command_options* op
 
     status = kitchen_initialize(&(struct kitchen_init_options) {
         .recipe = options->recipe,
-        .project_path = cwd,
+        .project_path = options->cwd,
         .pkg_environment = NULL,
         .confined = options->recipe->environment.build.confinement,
         .target_platform = options->platform,

--- a/tools/bake/main.c
+++ b/tools/bake/main.c
@@ -138,7 +138,7 @@ static int __add_ingredient(struct recipe* recipe, const char* name)
     }
 
     memset(ingredient, 0, sizeof(struct recipe_ingredient));
-    ingredient->name = strdup(name);
+    ingredient->name = platform_strdup(name);
     ingredient->type = RECIPE_INGREDIENT_TYPE_HOST;
     ingredient->source.type = INGREDIENT_SOURCE_TYPE_REPO;
     if (ingredient->name == NULL) {
@@ -213,11 +213,11 @@ static int __parse_cc_switch(const char* value, const char** platformOut, const 
 
     separator = strchr(equal, '/');
     if (separator) {
-        *platformOut = strndup(equal, separator - equal);
-        *archOut     = strdup(separator + 1);
+        *platformOut = platform_strndup(equal, separator - equal);
+        *archOut     = platform_strdup(separator + 1);
     } else {
-        *platformOut = strdup(CHEF_PLATFORM_STR);
-        *archOut     = strdup(equal);
+        *platformOut = platform_strdup(CHEF_PLATFORM_STR);
+        *archOut     = platform_strdup(equal);
     }
     return 0;
 }

--- a/tools/order/commands/info.c
+++ b/tools/order/commands/info.c
@@ -120,7 +120,7 @@ static void __print_platform(struct chef_platform* platform)
 
 static char* __strip_newlines(const char* text)
 {
-    char* result = strdup(text);
+    char* result = platform_strdup(text);
     char* ptr    = result;
     while (*ptr != '\0') {
         if (*ptr == '\n') {
@@ -323,7 +323,7 @@ int info_main(int argc, char** argv)
                 // do this only once
                 if (params.publisher == NULL) {
                 // assume this is the pack name
-                    packCopy = strdup(argv[i]);
+                    packCopy = platform_strdup(argv[i]);
                     status   = __parse_packname(packCopy, &params);
                     if (status != 0) {
                         free(packCopy);

--- a/tools/order/commands/package.c
+++ b/tools/order/commands/package.c
@@ -58,7 +58,7 @@ static const char* __get_publisher_name(void)
         return NULL;
     }
 
-    name = strdup(chef_account_get_publisher_name(account));
+    name = platform_strdup(chef_account_get_publisher_name(account));
     chef_account_free(account);
     return name;
 }

--- a/tools/order/commands/publish.c
+++ b/tools/order/commands/publish.c
@@ -66,7 +66,7 @@ static int __ensure_account_setup(char** publisherOut)
         return -1;
     }
 
-    *publisherOut = strdup(chef_account_get_publisher_name(account));
+    *publisherOut = platform_strdup(chef_account_get_publisher_name(account));
 
     chef_account_free(account);
     return 0;

--- a/tools/serve/commands/install.c
+++ b/tools/serve/commands/install.c
@@ -96,8 +96,8 @@ static int __parse_package_identifier(const char* id, const char** publisherOut,
         return -1;
     }
 
-    *publisherOut = strdup(names[0]);
-    *nameOut      = strdup(names[1]);
+    *publisherOut = platform_strdup(names[0]);
+    *nameOut      = platform_strdup(names[1]);
     strsplit_free(names);
     return 0;
 }
@@ -310,7 +310,7 @@ static int __verify_package(const char* path, char** infoNameOut, char** publish
         }
 
         *infoNameOut  = __get_unsafe_infoname(package, version);
-        *publisherOut = strdup("unverified");
+        *publisherOut = platform_strdup("unverified");
     } else {
         // verify package signature
         status = __verify_package_signature(path, publisherOut);
@@ -397,8 +397,8 @@ int install_main(int argc, char** argv)
         }
 
         // store publisher and the informational name
-        publisher = strdup(params.publisher);
-        infoName  = strdup(package);
+        publisher = platform_strdup(params.publisher);
+        infoName  = platform_strdup(package);
 
         // we only allow installs from native packages
         params.platform = CHEF_PLATFORM_STR;


### PR DESCRIPTION
The next version of Chef. A lot of fixes has gone into this and some improved windows support


### Commits in chef 1.2.1
many: several runtime fixes and crash fixes
many: bump version, fix a couple of json issues
libs/chefclient: fix saving of settings after having switched uid on … 
cmake: install bake/serve-exec as admin required
many: several build fixes, fixes to the hello-world recipe
libs/platform/windows: implement cpucount, getcwd, getuserdir and mkd… 
many: apply some styling updates, fix bug in cache