### PR TITLE
libs/kitchen: dummy variables for struct

### DIFF
--- a/libs/kitchen/include/chef/kitchen.h
+++ b/libs/kitchen/include/chef/kitchen.h
@@ -61,10 +61,12 @@ struct kitchen_setup_options {
 
 struct kitchen_purge_options {
     // TODO
+    int dummy;
 };
 
 struct kitchen_recipe_purge_options {
     // TODO
+    int dummy;
 };
 
 struct kitchen {


### PR DESCRIPTION
We cant have empty structs on windows